### PR TITLE
Add button options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "1.1-dev"
         }
     }
 }

--- a/src/Type/OperationType.php
+++ b/src/Type/OperationType.php
@@ -25,9 +25,9 @@ class OperationType extends AbstractType
         ;
 
         $builder
-            ->add('confirm', $submitType, ['label' => '確認'])
-            ->add('back',    $submitType, ['label' => '戻る'])
-            ->add('commit',  $submitType, ['label' => '送信'])
+            ->add('confirm', $submitType, $options['confirm_options'])
+            ->add('back',    $submitType, $options['back_options'])
+            ->add('commit',  $submitType, $options['commit_options'])
         ;
     }
 
@@ -48,7 +48,10 @@ class OperationType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'mapped' => false,
+            'mapped'          => false,
+            'confirm_options' => ['label' => 'Confirm'],
+            'back_options'    => ['label' => 'Back'],
+            'commit_options'  => ['label' => 'Commit'],
         ]);
     }
 

--- a/tests/Type/OperationTypeTest.php
+++ b/tests/Type/OperationTypeTest.php
@@ -11,9 +11,9 @@ class OperationTypeTest extends TypeTestCase
         $form = $this->factory->create(CompatibilityHelper::isFormLegacy() ? 'confirmable_form_operation' : 'Issei\ConfirmableForm\Type\OperationType');
         $this->assertCount(3, $form);
 
-        $this->assertEquals('確認', $form->get('confirm')->getConfig()->getOption('label'));
-        $this->assertEquals('戻る', $form->get('back')->getConfig()->getOption('label'));
-        $this->assertEquals('送信', $form->get('commit')->getConfig()->getOption('label'));
+        $this->assertEquals('Confirm', $form->get('confirm')->getConfig()->getOption('label'));
+        $this->assertEquals('Back', $form->get('back')->getConfig()->getOption('label'));
+        $this->assertEquals('Commit', $form->get('commit')->getConfig()->getOption('label'));
 
         $view = $form->createView();
 
@@ -24,6 +24,19 @@ class OperationTypeTest extends TypeTestCase
         foreach (['confirm', 'back', 'commit'] as $name) {
             $this->assertEquals('confirmable_form_operation_' . $name, array_slice($view[$name]->vars['block_prefixes'], -2, 1)[0]);
         }
+    }
+
+    public function testButtonOptions()
+    {
+        $form = $this->factory->create(CompatibilityHelper::isFormLegacy() ? 'confirmable_form_operation' : 'Issei\ConfirmableForm\Type\OperationType', null, [
+            'confirm_options' => ['label' => '確認'],
+            'back_options' => ['label' => '戻る'],
+            'commit_options' => ['label' => '送信'],
+        ]);
+
+        $this->assertEquals('確認', $form->get('confirm')->getConfig()->getOption('label'));
+        $this->assertEquals('戻る', $form->get('back')->getConfig()->getOption('label'));
+        $this->assertEquals('送信', $form->get('commit')->getConfig()->getOption('label'));
     }
 
     public function testSubmit()


### PR DESCRIPTION
Including small BC break:

- The default label of buttons has been changed:
  - Confirm button: `確認` -> `Confirm`
  - Back button: `戻る` -> `Back`
  - Commit button: `送信` -> `Send`